### PR TITLE
Add ingress rule for flannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then perform the following commands on the root folder:
 | Name                | Description                              |
 | ------------------- | ---------------------------------------- |
 | security_group_name | The security group used in the cluster   |
+| private_network_id  | The private network used in the cluster  |
 | worker_info         | The worker information in cluster        |
 | control_plane_info  | The control plane information in cluster |
 

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
   port_ssh     = 22
   port_kubectl = 6443
   port_kubelet = 10250
+  port_flannel = 8472
 
   pod_cidr = "10.244.0.0/16"
 
@@ -191,5 +192,27 @@ resource "nifcloud_security_group_rule" "kubelet_from_control_plane" {
   from_port                  = local.port_kubelet
   to_port                    = local.port_kubelet
   protocol                   = "TCP"
+  source_security_group_name = nifcloud_security_group.cp.group_name
+}
+
+resource "nifcloud_security_group_rule" "flannel_from_worker" {
+  security_group_names = [
+    nifcloud_security_group.cp.group_name
+  ]
+  type                       = "IN"
+  from_port                  = local.port_flannel
+  to_port                    = local.port_flannel
+  protocol                   = "UDP"
+  source_security_group_name = nifcloud_security_group.wk.group_name
+}
+
+resource "nifcloud_security_group_rule" "flannel_from_control_plane" {
+  security_group_names = [
+    nifcloud_security_group.wk.group_name,
+  ]
+  type                       = "IN"
+  from_port                  = local.port_flannel
+  to_port                    = local.port_flannel
+  protocol                   = "UDP"
   source_security_group_name = nifcloud_security_group.cp.group_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,11 @@ output "security_group_name" {
   }
 }
 
+output "private_network_id" {
+  description = "The private network used in the cluster"
+  value       = nifcloud_private_lan.this.id
+}
+
 output "worker_info" {
   description = "The worker information in cluster"
   value = { for v in module.worker : v.instance_id => {


### PR DESCRIPTION
I faced a problem accessing a pod from a pod on another node since no rule for flannel port is set. Adding a rule for 8472/udp solved this issue.

For more information, please refer https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan

Besides, I added an output that shows the network id. This is similar to https://github.com/ystkfujii/terraform-nifcloud-k8s-infrastructure/pull/4